### PR TITLE
Fix checker input description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ With configurations
 | `checkstyle_input` | bool    | `build/reports/checkstyle/main.xml`     | input file of generating SpotBugs annotation. |
 | `junit_test_src_dir` | bool    | `src/test/java`     | test source root directory. |
 | `matrix` | bool    | `false`     | matrix context. |
-| `checker` | bool    | `` (Search for all supporting tool outputs) | enabled checker list (comma separated string) |
+| `checker` | string  | empty string (Search for all supporting tool outputs) | enabled checker list (comma separated string) |
 
 ## License
 


### PR DESCRIPTION
From the following code, it appears that the type of `checker` is expected to be string.

https://github.com/project-tsurugi/tsurugi-annotations-action/blob/78e3a1968091e4de4dba67bd190a83c9b2760ad3/src/main.ts#L13-L34